### PR TITLE
Cors middleware

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -4,6 +4,7 @@ import { RouteAdders, DenootState, ListeningCallback, RenderEngineCallback, Rout
 import { stackListener } from "./src/stack.ts";
 
 import staticMiddleware from "./src/middleware/static.ts";
+import cors from "./src/middleware/cors.ts";
 
 
 
@@ -79,9 +80,12 @@ export const app = (port: number, hostname?: string, listeningCallback?: Listeni
 
 }
 
-
-
 export default app;
+
+export {
+    cors
+};
+
 
 /**
  * This is extremely infuriating but currently TSC does

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ After starting open [localhost:3000](http://localhost:3000)
     - [Consuming Request Body](#consuming-request-body)
     - [Setting Status Code](#setting-status-code)
     - [Static Routing](#static-routing)
+    - [Cors](#cors)
     - [Request And Response Headers](#request-and-response-headers)
     - [Wildcard Route](#wildcard-route)
     - [Multiple Paths/Routes](#multiple-pathsroutes)
@@ -356,6 +357,45 @@ app.static("/public", {
 
 __Note:__ By default Denoot will **not** allow [dotfiles](https://en.wikipedia.org/wiki/Hidden_file_and_hidden_directory) to be served or displayed in auto index. If you absolutely, 100% know what you're doing you can change this behavior by setting `res.state.allowDotFiles` to `true`.
 
+
+## Cors
+[⬆️ Table of Contents ⬆️](#table-of-contents)
+
+
+If you want to enable cors you can use the build inmiddle ware `cors`
+```ts
+import * as Denoot from "https://deno.land/x/denoot/mod.ts";
+
+app.use(Denoot.cors([ "https://example.com", "https://sub.example.com" ])); // Whoo we have Cors
+```
+You can add also add options, these are the default values
+
+```ts
+const options = {
+    continue: false,    // If the route stack should continue after cors call
+    referer: false,     // If you want to use Referer instead of Origin header
+    varyOrigin: true,   // Adds the header "Vary: Origin"
+    memoize: true,      // Memoizes cors value
+    allMethods: false   // If false cors will only run on OPTIONS call
+};
+
+app.use(Denoot.cors("https://example.com",options));
+```
+### Example:
+```ts
+app.use(Denoot.cors((req, res, origin) => {
+
+    if(origin.match(/^https?:\/\/localhost:8080\/?$/)) {
+        return true;
+    }
+
+    return false;
+
+}));
+```
+
+
+**Note:** Remember to turn off memoize and varyOrigin if the cors function isn't a pure function.
 
 ## Request And Response Headers
 [⬆️ Table of Contents ⬆️](#table-of-contents)

--- a/scripts.json
+++ b/scripts.json
@@ -28,6 +28,10 @@
     "test_refactoring": {
       "cmd": "deno run --unstable --allow-read --allow-net ./tests/test_refactoring.ts",
       "desc": "refactoring "
+    },
+    "test_cors": {
+      "cmd": "deno run --unstable --allow-read --allow-net ./tests/test_cors.ts",
+      "desc": "Cors "
     }
   }
 }

--- a/src/classes/DenootResponse.ts
+++ b/src/classes/DenootResponse.ts
@@ -86,8 +86,8 @@ export default class DenootResponse {
     /**
      * Makes the response empty. Stack.ts Controlls the resonponse after that
      */
-    setEmpty() {
-        this._empty = true;
+    setEmpty(empty: boolean = true) {
+        this._empty = empty;
         return this;
     }
 
@@ -145,6 +145,9 @@ export default class DenootResponse {
         return this._body.join("");
     }
 
+    /**
+     * If the current response is empty
+     */
     get empty() {
         return this._empty;
     }

--- a/src/classes/DenootResponse.ts
+++ b/src/classes/DenootResponse.ts
@@ -21,6 +21,7 @@ export default class DenootResponse {
     private _buffer?: Deno.File | Uint8Array;
     public _req!: Request;
     private _status: number = 200;
+    private _empty: boolean = false;
 
     /**
      * @internal
@@ -83,6 +84,14 @@ export default class DenootResponse {
 
 
     /**
+     * Makes the response empty. Stack.ts Controlls the resonponse after that
+     */
+    setEmpty() {
+        this._empty = true;
+        return this;
+    }
+
+    /**
      * Send the response as HTML
      * @param value HTML as string
      */
@@ -134,6 +143,10 @@ export default class DenootResponse {
      */
     get body() {
         return this._body.join("");
+    }
+
+    get empty() {
+        return this._empty;
     }
 
     /**

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,36 +1,55 @@
 import { Cors, Next, Request, Response } from "../../types/definitions.d.ts";
 import { map } from "../routing/routes.ts";
 
-export default (cors: Cors) => {
+interface CorsOptions {
+    continue?: boolean,
+    referer?: boolean
+}
+
+const defaultCorsOptions: CorsOptions = {
+    continue: false,
+    referer: false
+}
+
+export default (cors: Cors, options: CorsOptions = defaultCorsOptions) => {
     const memoize = new Map<string, boolean>();
 
     return async (req: Request, res: Response, next: Next) => {
-        const origin = req.headers.get("Origin");
+        if(req.method === "OPTIONS") {
 
-        if(origin === null) {
-            // Not a cors call
-            return next();
-        }
+            const origin = req.headers.get(options.referer ? "Referer" : "Origin");
 
-        if(memoize.has(origin)) {
-            if(memoize.get(origin)) {
+            if(origin === null) {
+                // Not a cors call
+                return next();
+            }
+    
+            if(memoize.has(origin)) {
+                if(memoize.get(origin)) {
+                    res.headers.set("Access-Control-Allow-Origin", "*");
+                }
+                return next();
+            }
+            
+            const allowedOrigin = [
+                Array.isArray(cors)        && cors.includes(origin),
+                typeof cors === 'function' && await cors(req,res,origin),
+                typeof cors === 'string'   && cors === origin
+            ].includes(true)
+    
+            if(allowedOrigin) {
                 res.headers.set("Access-Control-Allow-Origin", "*");
             }
-            return next();
-        }
-        
-        const allowedOrigin = [
-            Array.isArray(cors)        && cors.includes(origin),
-            typeof cors === 'function' && await cors(req,res,origin),
-            typeof cors === 'string'   && cors === origin
-        ].includes(true)
 
-        if(allowedOrigin) {
-            res.headers.set("Access-Control-Allow-Origin", "*");
+            memoize.set(origin, allowedOrigin);
+    
+            if(!options.continue) {
+                return res.setEmpty().end();
+            }else {
+                next();
+            }
+        }else {
+            next();
         }
-        memoize.set(origin, allowedOrigin);
-
-        return next();
     }
-
 }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,0 +1,38 @@
+import { Cors, Next, Request, Response } from "../../types/definitions.d.ts";
+
+export default (cors: Cors) => {
+
+    return async (req: Request, res: Response, next: Next) => {
+        const origin = req.headers.get("Origin");
+
+        if(origin === null) {
+            // Not a cors call
+            return next();
+        }
+
+        if(Array.isArray(cors)) {
+            if(cors.includes(origin)) {
+                res.headers.set("Access-Control-Allow-Origin", "*");
+            }
+            return next();
+        }
+
+        if(typeof cors === 'function') {
+            if(await cors(req,res,origin)) {
+                res.headers.set("Access-Control-Allow-Origin", "*");
+            }
+            return next();
+        }
+        
+        if(typeof cors === 'string') {
+            if(cors === origin) {
+                res.headers.set("Access-Control-Allow-Origin", "*");
+            }
+            return next();
+        }
+        
+
+        return next();
+    }
+
+}

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -10,27 +10,15 @@ export default (cors: Cors) => {
             return next();
         }
 
-        if(Array.isArray(cors)) {
-            if(cors.includes(origin)) {
-                res.headers.set("Access-Control-Allow-Origin", "*");
-            }
-            return next();
-        }
+        const allowedOrigin = [
+            Array.isArray(cors)        && cors.includes(origin),
+            typeof cors === 'function' && await cors(req,res,origin),
+            typeof cors === 'string'   && cors === origin
+        ].includes(true)
 
-        if(typeof cors === 'function') {
-            if(await cors(req,res,origin)) {
-                res.headers.set("Access-Control-Allow-Origin", "*");
-            }
-            return next();
+        if(allowedOrigin) {
+            res.headers.set("Access-Control-Allow-Origin", "*");
         }
-        
-        if(typeof cors === 'string') {
-            if(cors === origin) {
-                res.headers.set("Access-Control-Allow-Origin", "*");
-            }
-            return next();
-        }
-        
 
         return next();
     }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,6 +1,8 @@
 import { Cors, Next, Request, Response } from "../../types/definitions.d.ts";
+import { map } from "../routing/routes.ts";
 
 export default (cors: Cors) => {
+    const memoize = new Map<string, boolean>();
 
     return async (req: Request, res: Response, next: Next) => {
         const origin = req.headers.get("Origin");
@@ -10,6 +12,13 @@ export default (cors: Cors) => {
             return next();
         }
 
+        if(memoize.has(origin)) {
+            if(memoize.get(origin)) {
+                res.headers.set("Access-Control-Allow-Origin", "*");
+            }
+            return next();
+        }
+        
         const allowedOrigin = [
             Array.isArray(cors)        && cors.includes(origin),
             typeof cors === 'function' && await cors(req,res,origin),
@@ -19,6 +28,7 @@ export default (cors: Cors) => {
         if(allowedOrigin) {
             res.headers.set("Access-Control-Allow-Origin", "*");
         }
+        memoize.set(origin, allowedOrigin);
 
         return next();
     }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -31,7 +31,6 @@ export default (cors: Cors, _options: CorsOptions = defaultCorsOptions) => {
 
     return async (req: Request, res: Response, next: Next) => {
         if (req.method === "OPTIONS" || options.allMethods) {
-            console.log(memoize);
 
             const origin = req.headers.get(options.referer ? "Referer" : "Origin");
 

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -4,14 +4,16 @@ interface CorsOptions {
     continue?: boolean,
     referer?: boolean,
     varyOrigin?: boolean,
-    memoize?: boolean
+    memoize?: boolean,
+    allMethods?: boolean
 }
 
 const defaultCorsOptions: CorsOptions = {
     continue: false,
     referer: false,
     varyOrigin: true,
-    memoize: true
+    memoize: true,
+    allMethods: false
 }
 
 function setCorsHeader(res: Response, options: CorsOptions) {
@@ -28,7 +30,7 @@ export default (cors: Cors, _options: CorsOptions = defaultCorsOptions) => {
     const memoize = new Map<string, boolean>();
 
     return async (req: Request, res: Response, next: Next) => {
-        if (req.method === "OPTIONS") {
+        if (req.method === "OPTIONS" || options.allMethods) {
             console.log(memoize);
 
             const origin = req.headers.get(options.referer ? "Referer" : "Origin");
@@ -44,6 +46,7 @@ export default (cors: Cors, _options: CorsOptions = defaultCorsOptions) => {
                 if (memoize.get(origin)) {
                     setCorsHeader(res,options);
                 }
+                res.setEmpty().end();
                 return next();
             }
 

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -181,9 +181,16 @@ export const stackListener = async (state: State, server: HTTP.Server) => {
 
             }
 
+            clearTimeout(timeout);
+
+            if(res.empty) {
+                return denoReq
+                    .respond({ body: "", headers: res.headers, status: 204 })
+                    .catch(() => void 0);
+            }
+
             const createdBody = res.buffer ?? res.body;
 
-            clearTimeout(timeout);
 
             if (e404 || !createdBody && !(res.getStatus >= 300 && res.getStatus < 400)) {
                 // prompt 404 middleware

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -172,8 +172,6 @@ export const stackListener = async (state: State, server: HTTP.Server) => {
 
                 const match = matchRequestWithRoute(req, routeStackItem);
 
-                console.log(match);
-
                 if (!match) continue searchStack;
                 else if (e404) e404 = false;
 

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -164,13 +164,13 @@ export const stackListener = async (state: State, server: HTTP.Server) => {
             res._req = req;
 
             let e404 = true;
+      
 
             searchStack: for (const routeStackItem of state.routingStack) {
 
                 debug && console.log("Match request");
 
                 const match = matchRequestWithRoute(req, routeStackItem);
-
 
                 if (!match) continue searchStack;
                 else if (e404) e404 = false;

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -172,6 +172,8 @@ export const stackListener = async (state: State, server: HTTP.Server) => {
 
                 const match = matchRequestWithRoute(req, routeStackItem);
 
+                console.log(match);
+
                 if (!match) continue searchStack;
                 else if (e404) e404 = false;
 

--- a/tests/test_cors.ts
+++ b/tests/test_cors.ts
@@ -2,9 +2,7 @@ import * as Denoot from "../mod.ts";
 
 const app = Denoot.app(8000, "0.0.0.0", ({ localhostURL }) => console.log(`Listening on ${localhostURL}`))
 
-app.use(Denoot.cors((req, res, origin) => {
-    return false;
-}));
+app.use(Denoot.cors("http://localhost:8080"));
 
 app.get("/what", (req, res) => {
     res.send("woah");

--- a/tests/test_cors.ts
+++ b/tests/test_cors.ts
@@ -2,7 +2,7 @@ import * as Denoot from "../mod.ts";
 
 const app = Denoot.app(8000, "0.0.0.0", ({ localhostURL }) => console.log(`Listening on ${localhostURL}`))
 
-app.use(Denoot.cors("http://localhost:8080",true));
+app.use(Denoot.cors("http://localhost:8080"));
 
 app.get("/what", (req, res) => {
     res.send("woah");

--- a/tests/test_cors.ts
+++ b/tests/test_cors.ts
@@ -1,0 +1,11 @@
+import * as Denoot from "../mod.ts";
+
+const app = Denoot.app(8000, "0.0.0.0", ({ localhostURL }) => console.log(`Listening on ${localhostURL}`))
+
+app.use(Denoot.cors((req, res, origin) => {
+    return false;
+}));
+
+app.get("/what", (req, res) => {
+    res.send("woah");
+});

--- a/tests/test_cors.ts
+++ b/tests/test_cors.ts
@@ -2,7 +2,11 @@ import * as Denoot from "../mod.ts";
 
 const app = Denoot.app(8000, "0.0.0.0", ({ localhostURL }) => console.log(`Listening on ${localhostURL}`))
 
-app.use(Denoot.cors("http://localhost:8080"));
+app.use(Denoot.cors([
+    "http://localhost:8080",
+    "http://app.localhost:8080",
+    "http://api.localhost:8080"
+]));
 
 app.get("/what", (req, res) => {
     res.send("woah");

--- a/tests/test_cors.ts
+++ b/tests/test_cors.ts
@@ -2,7 +2,7 @@ import * as Denoot from "../mod.ts";
 
 const app = Denoot.app(8000, "0.0.0.0", ({ localhostURL }) => console.log(`Listening on ${localhostURL}`))
 
-app.use(Denoot.cors("http://localhost:8080"));
+app.use(Denoot.cors("http://localhost:8080",true));
 
 app.get("/what", (req, res) => {
     res.send("woah");

--- a/types/definitions.d.ts
+++ b/types/definitions.d.ts
@@ -22,6 +22,7 @@ export type RenderEngine = (renderCallback: RenderEngineCallback) => unknown;
 export type StaticCallback = (route: DeclarePath, options: StaticRouteOptions) => unknown;
 export type AllowedParameterTypes = "string" | "number" | "any" | "int";
 export type AutoIndexRenderer = (req: Request, res: Response, files: AutoIndexFile[]) => void;
+export type Cors = null | string | string[] | ((req: Request,res: Response,origin: string) => Promise<boolean> | boolean);
 
 export interface StaticRouteBaseOptions {
     index: string;
@@ -162,5 +163,4 @@ export interface RouteAdders {
      * ```
      */
     static: StaticCallback;
-
 }


### PR DESCRIPTION
Added cors middleware to make using cors easier
```ts
import * as Denoot from "https://deno.land/x/denoot/mod.ts";

app.use(Denoot.cors([ "https://example.com", "https://sub.example.com" ])); // Whoo we have Cors
```